### PR TITLE
Use dh_install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -59,7 +59,7 @@ binary-arch: build install
 	dh_installchangelogs 
 	dh_installdocs
 	dh_installexamples
-#	dh_install
+	dh_install
 #	dh_installmenu
 #	dh_installdebconf	
 #	dh_installlogrotate


### PR DESCRIPTION
Otherwise the `install` file is ignored. This causes the package to be
empty and fail to install because postinst tries to add the missing
keys.

Reason I need this: have a clean bootstrapped maui for my CI
system.